### PR TITLE
Feat/#17 유저 알람 상태 api

### DIFF
--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
@@ -35,7 +35,7 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @PatchMapping("/my/notification")
-    public ApiResponse<MemberInfoResponse> updateAlarm(@AuthenticationPrincipal Long memberId) {
+    public ApiResponse<MemberInfoResponse> updateNoti(@AuthenticationPrincipal Long memberId) {
         MemberInfoResponse response = memberService.updateNotificationOn(memberId);
         return ApiResponse.success(MemberSuccessCode.MEMBER_NOTI_UPDATE, response);
     }

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
@@ -35,8 +35,9 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @PatchMapping("/my/notification")
-    public ApiResponse<MemberInfoResponse> updateNoti(@AuthenticationPrincipal Long memberId) {
-        MemberInfoResponse response = memberService.updateNotificationOn(memberId);
+    public ApiResponse<MemberInfoResponse> updateNotificationStatus(
+        @AuthenticationPrincipal Long memberId) {
+        MemberInfoResponse response = memberService.updateNotificationStatus(memberId);
         return ApiResponse.success(MemberSuccessCode.MEMBER_NOTI_UPDATE, response);
     }
 

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
@@ -34,4 +34,11 @@ public class MemberController implements MemberControllerDocs {
         return ApiResponse.success(MemberSuccessCode.MEMBER_INFO_UPDATE, response);
     }
 
+    @PatchMapping("/my/notification")
+    public ApiResponse<MemberInfoResponse> updateAlarm(@AuthenticationPrincipal Long memberId) {
+        MemberInfoResponse response = memberService.updateNotificationOn(memberId);
+        return ApiResponse.success(MemberSuccessCode.MEMBER_NOTI_UPDATE, response);
+    }
+
+
 }

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
@@ -2,6 +2,7 @@ package com.dnd.sub.domain.member.controller;
 
 import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
 import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
+import com.dnd.sub.domain.member.dto.response.MemberSuccessCode;
 import com.dnd.sub.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -29,5 +30,13 @@ public interface MemberControllerDocs {
     )
     @PatchMapping("/my/info")
     ApiResponse<MemberInfoResponse> updateMemberInfo(@AuthenticationPrincipal Long memberId, @RequestBody UpdateMemberRequest request);
+
+    @Operation(
+        summary = "내 알람 상태 수정",
+        description = "내 이메일 알람 상태를 수정합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PatchMapping("/my/notification")
+    ApiResponse<MemberInfoResponse> updateNoti(@AuthenticationPrincipal Long memberId);
 
 }

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
@@ -37,6 +37,7 @@ public interface MemberControllerDocs {
         security = @SecurityRequirement(name = "Bearer Authentication")
     )
     @PatchMapping("/my/notification")
-    ApiResponse<MemberInfoResponse> updateNoti(@AuthenticationPrincipal Long memberId);
+    ApiResponse<MemberInfoResponse> updateNotificationStatus(
+        @AuthenticationPrincipal Long memberId);
 
 }

--- a/src/main/java/com/dnd/sub/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/dnd/sub/domain/member/dto/response/MemberInfoResponse.java
@@ -3,6 +3,6 @@ package com.dnd.sub.domain.member.dto.response;
 public record MemberInfoResponse(
     String email,
     String name,
-    boolean isNotificaionOn
+    boolean isNotificationOn
 ) {
 }

--- a/src/main/java/com/dnd/sub/domain/member/dto/response/MemberInfoResponse.java
+++ b/src/main/java/com/dnd/sub/domain/member/dto/response/MemberInfoResponse.java
@@ -2,6 +2,7 @@ package com.dnd.sub.domain.member.dto.response;
 
 public record MemberInfoResponse(
     String email,
-    String name
+    String name,
+    boolean isNotificaionOn
 ) {
 }

--- a/src/main/java/com/dnd/sub/domain/member/dto/response/MemberSuccessCode.java
+++ b/src/main/java/com/dnd/sub/domain/member/dto/response/MemberSuccessCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MemberSuccessCode implements SuccessCode {
     MEMBER_INFO_OK("MIS-201", HttpStatus.OK, "사용자 정보 조회 성공"),
-    MEMBER_INFO_UPDATE("MIS-202", HttpStatus.OK, "이메일 변경 완료");
+    MEMBER_INFO_UPDATE("MIS-202", HttpStatus.OK, "이메일 변경 완료"),
+    MEMBER_NOTI_UPDATE("MIS-203", HttpStatus.OK, "알람 상태 변경 완료");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
@@ -25,13 +25,23 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberInfoResponse getMemberInfo(Long memberId) {
         Member member = findById(memberId);
-        return new MemberInfoResponse(member.getEmail(), member.getName());
+        return new MemberInfoResponse(member.getEmail(), member.getName(),
+            member.isNotificationOn());
     }
 
     @Transactional
     public MemberInfoResponse updateMemberInfo(Long memberId, UpdateMemberRequest request) {
         Member member = findById(memberId);
         member.updateEmail(request.email());
-        return new MemberInfoResponse(member.getEmail(), member.getName());
+        return new MemberInfoResponse(member.getEmail(), member.getName(),
+            member.isNotificationOn());
+    }
+
+    @Transactional
+    public MemberInfoResponse updateNotificationOn(Long memberId) {
+        Member member = findById(memberId);
+        member.updateIsNotificationOn();
+        return new MemberInfoResponse(member.getEmail(), member.getName(),
+            member.isNotificationOn());
     }
 }

--- a/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
@@ -38,7 +38,7 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberInfoResponse updateNotificationOn(Long memberId) {
+    public MemberInfoResponse updateNotificationStatus(Long memberId) {
         Member member = findById(memberId);
         member.updateIsNotificationOn();
         return new MemberInfoResponse(member.getEmail(), member.getName(),


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #17 


### 📝 작업 내용
- 유저 알람 상태 변경 api 구현
- 유저 정보에 알람 유무 반환

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a PATCH endpoint for signed-in users to toggle their email notification preference.
  * Member profile responses now include a notification status field.
  * Added a success response code for notification updates.

* **Documentation**
  * API docs updated to describe the new notification update endpoint and the added response field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->