### PR TITLE
Feat/#38 내구독 요약 조회 구현

### DIFF
--- a/src/main/java/com/dnd/sub/domain/auth/exception/TokenErrorCode.java
+++ b/src/main/java/com/dnd/sub/domain/auth/exception/TokenErrorCode.java
@@ -10,8 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum TokenErrorCode implements ErrorCode {
   EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED.value(), "TF-401", "만료된 토큰입니다."),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED.value(), "TF-402", "유효하지 않은 토큰입니다."),
-  NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND.value(), "TF-403", "찾을수 없는 유저입니다."),
-  REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "TF-404", "리프레시 토큰을 찾을 수 없습니다.");
+  REFRESH_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "TF-403", "리프레시 토큰을 찾을 수 없습니다.");
 
   private final int status;
   private final String code;

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -5,6 +5,7 @@ import com.dnd.sub.domain.subscription.dto.GetMySubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
 import com.dnd.sub.domain.subscription.dto.response.GetMySubscriptionsResponse;
 import com.dnd.sub.domain.subscription.dto.response.GetPaymentSoonResponse;
+import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
 import com.dnd.sub.domain.subscription.service.SubscriptionService;
 import com.dnd.sub.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -49,7 +50,6 @@ public class SubscriptionController {
         return ApiResponse.success(GET_MY_FAVORITES, response);
     }
 
-
     @GetMapping("/my/payment-soon")
     public ApiResponse<GetPaymentSoonResponse> getPaymentSoon(@AuthenticationPrincipal Long memberId) {
         List<GetPaymentSoonDto> services = subscriptionService.getPaymentSoon(memberId);
@@ -57,4 +57,12 @@ public class SubscriptionController {
 
         return ApiResponse.success(GET_PAYMENT_SOON, response);
     }
+
+    @GetMapping("/my/total-payments")
+    public ApiResponse<GetPaymentTotalResponse> getPaymentTotal(@AuthenticationPrincipal Long memberId) {
+        GetPaymentTotalResponse response = subscriptionService.getPaymentTotal(memberId);
+
+        return ApiResponse.success(GET_PAYMENT_TOTAL, response);
+    }
+
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDto.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDto.java
@@ -3,6 +3,8 @@ package com.dnd.sub.domain.subscription.dto;
 import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import com.dnd.sub.domain.subscription.entity.PayCycleUnitType;
 
+import java.time.LocalDate;
+
 public record GetMySubscriptionDto(
     Long id,
     String name,
@@ -12,6 +14,7 @@ public record GetMySubscriptionDto(
     String planName,
     int price,
     boolean isFavorites,
-    String imageUrl
+    String imageUrl,
+    LocalDate nextDueDay
 ) {
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetPaymentTotalResponse.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetPaymentTotalResponse.java
@@ -1,0 +1,10 @@
+package com.dnd.sub.domain.subscription.dto.response;
+
+public record GetPaymentTotalResponse(
+        String userName,
+        int totalAmount,
+        int remainingAmount,
+        int progressPercent,
+        int subCount
+){
+}

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum SubscriptionSuccessCode implements SuccessCode {
     GET_MY_SUBSCRIPTIONS(HttpStatus.OK.value(), "SS-201", "내 구독 서비스 전체 조회 성공"),
     GET_MY_FAVORITES(HttpStatus.OK.value(), "SS-202", "내 즐겨찾기 전체 조회 성공"),
-    GET_PAYMENT_SOON(HttpStatus.OK.value(), "SS-203", "결제 임박 서비스 조회 성공")
+    GET_PAYMENT_SOON(HttpStatus.OK.value(), "SS-203", "결제 임박 서비스 조회 성공"),
+    GET_PAYMENT_TOTAL(HttpStatus.OK.value(), "SS-211", "월간 결제 요약 조회")
     ;
 
     private final int status;

--- a/src/main/java/com/dnd/sub/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/entity/Subscription.java
@@ -47,8 +47,11 @@ public class Subscription extends BaseEntity {
     @Column(name = "plan_id", nullable = false)
     private Long planId;
 
-    @Column(name = "started_at", nullable = false)
+    @Column(name = "started_at")
     private LocalDate startedAt;
+
+    @Column(name = "previous_payment_day")
+    private LocalDate previousPaymentDay;
 
     @Column(name = "next_payment_day")
     private LocalDate nextPaymentDay;

--- a/src/main/java/com/dnd/sub/domain/subscription/entity/Subscription.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/entity/Subscription.java
@@ -76,6 +76,14 @@ public class Subscription extends BaseEntity {
         this.isFavorite = !this.isFavorite;
     }
 
+    public void updatePreviousPaymentDay(LocalDate date) {
+        this.previousPaymentDay = date;
+    }
+
+    public void updateNextPaymentDay(LocalDate date) {
+        this.nextPaymentDay = date;
+    }
+
     @Builder
     public Subscription(
         final Member member,
@@ -83,6 +91,7 @@ public class Subscription extends BaseEntity {
         final PaymentMethod paymentMethod,
         final Long planId,
         final LocalDate startedAt,
+        final LocalDate previousPaymentDay,
         final LocalDate nextPaymentDay,
         final int participantCount,
         final String payType,
@@ -94,6 +103,7 @@ public class Subscription extends BaseEntity {
         this.paymentMethod = paymentMethod;
         this.planId = planId;
         this.startedAt = startedAt;
+        this.previousPaymentDay = previousPaymentDay;
         this.nextPaymentDay = nextPaymentDay;
         this.participantCount = participantCount;
         this.payType = payType;

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepository.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepository.java
@@ -4,6 +4,7 @@ import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import com.dnd.sub.domain.subscription.controller.SubscriptionSortType;
 import com.dnd.sub.domain.subscription.dto.GetMySubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
+import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
 
 import java.util.List;
 
@@ -13,4 +14,6 @@ public interface SubscriptionQueryRepository {
     List<GetMySubscriptionDto> findMyFavorites(Long memberId, ProductCategoryType category, SubscriptionSortType sort);
 
     List<GetPaymentSoonDto> findPaymentSoon(Long memberId);
+
+    GetPaymentTotalResponse findPaymentTotal(Long memberId);
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -95,15 +95,10 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
         LocalDate startDay = today.withDayOfMonth(1);
         LocalDate endDay = today.withDayOfMonth(today.lengthOfMonth());
 
-        String userName = query
-                .select(m.name)
-                .from(m)
-                .where(m.id.eq(memberId))
-                .fetchOne();
-
         List<Tuple> tuples = query
-                .select(s, pp.price)
+                .select(m.name, s, pp.price)
                 .from(s)
+                .join(s.member, m)
                 .join(s.product, p)
                 .leftJoin(pp).on(pp.id.eq(s.planId))
                 .where(s.member.id.eq(memberId)
@@ -111,6 +106,11 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                 .fetch();
 
         if (tuples.isEmpty()) {
+            String userName = query
+                    .select(m.name)
+                    .from(m)
+                    .where(m.id.eq(memberId))
+                    .fetchOne();
             return new GetPaymentTotalResponse(userName, 0, 0, 0, 0);
         }
 

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -127,14 +127,19 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
             LocalDate nextPayDay = sub.getNextPaymentDay();
 
             // 이전 결제일이 이번달인 경우
-            boolean isPrevThisMonth = prevPayDay.isAfter(startDay.minusDays(1)) &&
-                    prevPayDay.isBefore(endDay.plusDays(1)) &&
-                    prevPayDay.isBefore(today.plusDays(1));
-
+            boolean isPrevThisMonth = false;
+            if (prevPayDay != null) {
+                isPrevThisMonth = !prevPayDay.isBefore(startDay) &&
+                        !prevPayDay.isAfter(endDay) &&
+                        !prevPayDay.isAfter(today);
+            }
             // 다음 결제일이 이번달인 경우
-            boolean isNextThisMonth = nextPayDay.isAfter(startDay.minusDays(1)) &&
-                    nextPayDay.isBefore(endDay.plusDays(1)) &&
-                    nextPayDay.isAfter(today);
+            boolean isNextThisMonth = false;
+            if (nextPayDay != null) {
+                isNextThisMonth = !nextPayDay.isBefore(startDay) &&
+                        !nextPayDay.isAfter(endDay) &&
+                        nextPayDay.isAfter(today);
+            }
 
             if (isPrevThisMonth || isNextThisMonth) {
                 totalAmount += price;

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.domain.subscription.repository;
 
+import com.dnd.sub.domain.member.entity.QMember;
 import com.dnd.sub.domain.product.entity.Product;
 import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import com.dnd.sub.domain.product.entity.QProduct;
@@ -7,6 +8,7 @@ import com.dnd.sub.domain.product.entity.QProductPlan;
 import com.dnd.sub.domain.subscription.controller.SubscriptionSortType;
 import com.dnd.sub.domain.subscription.dto.GetMySubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
+import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
 import com.dnd.sub.domain.subscription.entity.QSubscription;
 import com.dnd.sub.domain.subscription.entity.Subscription;
 import com.querydsl.core.BooleanBuilder;
@@ -28,6 +30,7 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
     private static final QSubscription s = QSubscription.subscription;
     private static final QProduct p = QProduct.product;
     private static final QProductPlan pp = QProductPlan.productPlan;
+    private static final QMember m = QMember.member;
 
     @Override
     public List<GetMySubscriptionDto> findMySubscriptions(Long memberId, ProductCategoryType category, SubscriptionSortType sort) {
@@ -84,6 +87,80 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                     sub.getNextPaymentDay()
             );
         }).toList();
+    }
+
+    @Override
+    public GetPaymentTotalResponse findPaymentTotal(Long memberId) {
+        LocalDate today = LocalDate.now();
+        LocalDate startDay = today.withDayOfMonth(1);
+        LocalDate endDay = today.withDayOfMonth(today.lengthOfMonth());
+
+        String userName = query
+                .select(m.name)
+                .from(m)
+                .where(m.id.eq(memberId))
+                .fetchOne();
+
+        List<Tuple> tuples = query
+                .select(s, pp.price)
+                .from(s)
+                .join(s.product, p)
+                .leftJoin(pp).on(pp.id.eq(s.planId))
+                .where(s.member.id.eq(memberId)
+                        .and(s.startedAt.isNotNull()))
+                .fetch();
+
+        if (tuples.isEmpty()) {
+            return new GetPaymentTotalResponse(userName, 0, 0, 0, 0);
+        }
+
+        int totalAmount = 0;
+        int usedAmount = 0;
+        int remainingAmount = 0;
+        int subCount = tuples.size();
+
+        for (Tuple tuple : tuples) {
+            Subscription sub = tuple.get(s);
+            Integer price = tuple.get(pp.price);
+
+            LocalDate prevPayDay = sub.getPreviousPaymentDay();
+            LocalDate nextPayDay = sub.getNextPaymentDay();
+
+            // 이전 결제일이 이번달인 경우
+            boolean isPrevThisMonth = prevPayDay.isAfter(startDay.minusDays(1)) &&
+                    prevPayDay.isBefore(endDay.plusDays(1)) &&
+                    prevPayDay.isBefore(today.plusDays(1));
+
+            // 다음 결제일이 이번달인 경우
+            boolean isNextThisMonth = nextPayDay.isAfter(startDay.minusDays(1)) &&
+                    nextPayDay.isBefore(endDay.plusDays(1)) &&
+                    nextPayDay.isAfter(today);
+
+            if (isPrevThisMonth || isNextThisMonth) {
+                totalAmount += price;
+            }
+
+            if (isPrevThisMonth) {
+                usedAmount += price;
+            }
+
+            if (isNextThisMonth) {
+                remainingAmount += price;
+            }
+        }
+
+        int progressPercentage = 0;
+        if (totalAmount > 0) {
+            progressPercentage = (100 * usedAmount) / totalAmount;
+        }
+
+        return new GetPaymentTotalResponse(
+                userName,
+                totalAmount,
+                remainingAmount,
+                progressPercentage,
+                subCount
+        );
     }
 
     private List<GetMySubscriptionDto> findSubscriptions(BooleanBuilder builder,

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -190,14 +190,14 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                 planName,
                 price,
                 sub.isFavorite(),
-                prod.getImageUrl()
+                    prod.getImageUrl(),
+                    sub.getNextPaymentDay()
             );
         }).toList();
 
         return services;
     }
-
-
+    
     private OrderSpecifier<?>[] buildOrderSpec(SubscriptionSortType sort, QSubscription s, QProduct p, QProductPlan pp) {
         if (sort == null) {
             return new OrderSpecifier<?>[]{ p.name.asc() };

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -155,7 +155,7 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
         }
 
         return new GetPaymentTotalResponse(
-                userName,
+                tuples.get(0).get(m.name),
                 totalAmount,
                 remainingAmount,
                 progressPercentage,

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -4,6 +4,7 @@ import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import com.dnd.sub.domain.subscription.controller.SubscriptionSortType;
 import com.dnd.sub.domain.subscription.dto.GetMySubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
+import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
 import com.dnd.sub.domain.subscription.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,5 +31,9 @@ public class SubscriptionService {
 
     public List<GetPaymentSoonDto> getPaymentSoon(Long memberId) {
         return subscriptionRepository.findPaymentSoon(memberId);
+    }
+
+    public GetPaymentTotalResponse getPaymentTotal(Long memberId) {
+        return subscriptionRepository.findPaymentTotal(memberId);
     }
 }

--- a/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
@@ -1,8 +1,8 @@
 package com.dnd.sub.global.security.jwt;
 
+import com.dnd.sub.domain.member.exception.MemberErrorCode;
+import com.dnd.sub.domain.member.exception.MemberException;
 import com.dnd.sub.domain.member.repository.MemberRepository;
-import com.dnd.sub.domain.auth.exception.TokenErrorCode;
-import com.dnd.sub.domain.auth.exception.TokenException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,7 +36,7 @@ public class JwtFilter extends OncePerRequestFilter {
             Long memberId = jwtProvider.extractUserId(token);
 
             memberRepository.findById(memberId)
-                .orElseThrow(() -> new TokenException(TokenErrorCode.NOT_FOUND_MEMBER));
+                    .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
             Authentication authentication = new UsernamePasswordAuthenticationToken(
                 memberId, null, Collections.emptyList());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 spring:
-  profiles.active: dev
+  profiles.active: local

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 spring:
-  profiles.active: local
+  profiles.active: dev


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #38 

### 📝 작업 내용
- 내 월간 구독 요약 조회를 구현하였습니다.
- 바뀐 에러코드 규칙에 따라 에러코드를 수정하였습니다.
- 요구사항에 맞춰 시작일은 nullable하게 바꾸었습니다.
- 바뀐명세서에 따라 내구독 조회, 즐겨찾는 구독 조회에 다음 결제일도 반환하게 수정하였습니다

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added “My Monthly Payment Summary” endpoint to view user name, total/remaining amounts, progress percent, and subscription count.

- Enhancements
  - Subscription list now shows the next billing date for each subscription.
  - Subscription records include previous payment day for more accurate billing info.

- Bug Fixes
  - Standardized not-found handling during authentication for more consistent responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->