### PR TITLE
Feat/#41 logout

### DIFF
--- a/src/main/java/com/dnd/sub/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/sub/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.domain.auth.controller;
 
+import com.dnd.sub.domain.auth.dto.response.AuthSuccessCode;
 import com.dnd.sub.domain.auth.dto.response.TokenResponse;
 import com.dnd.sub.domain.auth.service.AuthService;
 import com.dnd.sub.global.dto.ApiResponse;
@@ -37,7 +38,7 @@ public class AuthController {
         ResponseCookie responseCookie = CookieUtil.createCookie("refresh_token",
             tokenResponse.refreshToken(), 60 * 60 * 24 * 14);
         response.addHeader(HttpHeaders.SET_COOKIE, responseCookie.toString());
-        return ApiResponse.success(GlobalSuccessCode.OK);
+        return ApiResponse.success(AuthSuccessCode.REISSUE_OK);
     }
 
 }

--- a/src/main/java/com/dnd/sub/domain/auth/dto/response/AuthSuccessCode.java
+++ b/src/main/java/com/dnd/sub/domain/auth/dto/response/AuthSuccessCode.java
@@ -1,0 +1,17 @@
+package com.dnd.sub.domain.auth.dto.response;
+
+import com.dnd.sub.global.enums.SuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode implements SuccessCode {
+    REISSUE_OK(200, "AS-202", "토큰 재발급 성공"),
+    LOGOUT_OK(200, "AS-203", "로그아웃 성공")
+    ;
+
+    private final int status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/dnd/sub/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/sub/domain/auth/service/AuthService.java
@@ -33,7 +33,5 @@ public class AuthService {
 
         return new TokenResponse(newAccess, refreshToken);
     }
-
-
-
+    
 }

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -1,10 +1,14 @@
 package com.dnd.sub.global.config;
 
 import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
+import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
+import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
 import com.dnd.sub.global.security.handler.CustomSuccessHandler;
 import com.dnd.sub.global.security.jwt.JwtFilter;
 import com.dnd.sub.global.security.jwt.JwtProvider;
 import java.util.List;
+
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,25 +27,33 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class SecurityConfig {
 
+  private final CustomOAuth2LogoutHandler customOAuth2LogoutHandler;
   private final CustomOAuth2UserService customOAuth2UserService;
   private final CustomSuccessHandler customSuccessHandler;
   private final JwtProvider jwtProvider;
   private final JwtFilter jwtFilter;
+  private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
   @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+  public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2LogoutHandler customOAuth2LogoutHandler) throws Exception {
     http
         .cors(cors -> cors.configurationSource(configurationSource()))
         .csrf(AbstractHttpConfigurer::disable)
         .formLogin(AbstractHttpConfigurer::disable)
         .httpBasic(AbstractHttpConfigurer::disable)
         .oauth2Login((oauth2) -> oauth2
-            .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                 .userService(customOAuth2UserService))
-            .successHandler(customSuccessHandler))
+                .successHandler(customSuccessHandler))
         .sessionManagement(s -> s.sessionCreationPolicy((SessionCreationPolicy.STATELESS)))
+            .logout(logout -> logout
+                    .logoutUrl("/api/auth/logout")
+                    .addLogoutHandler(customOAuth2LogoutHandler)
+                    .deleteCookies("refresh_token")
+                    .logoutSuccessHandler(customLogoutSuccessHandler)
+            )
         .authorizeHttpRequests(
-            a -> a.anyRequest().permitAll() //일단 다 허용
+                a -> a.anyRequest().permitAll() //일단 다 허용
         )
         .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -4,11 +4,10 @@ import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
 import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
 import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
 import com.dnd.sub.global.security.handler.CustomSuccessHandler;
+import com.dnd.sub.global.security.jwt.JwtAuthenticationEntryPoint;
 import com.dnd.sub.global.security.jwt.JwtFilter;
-import com.dnd.sub.global.security.jwt.JwtProvider;
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,7 +29,7 @@ public class SecurityConfig {
   private final CustomOAuth2LogoutHandler customOAuth2LogoutHandler;
   private final CustomOAuth2UserService customOAuth2UserService;
   private final CustomSuccessHandler customSuccessHandler;
-  private final JwtProvider jwtProvider;
+  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
   private final JwtFilter jwtFilter;
   private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
@@ -46,6 +45,9 @@ public class SecurityConfig {
                 .userService(customOAuth2UserService))
                 .successHandler(customSuccessHandler))
         .sessionManagement(s -> s.sessionCreationPolicy((SessionCreationPolicy.STATELESS)))
+            .exceptionHandling(exceptions -> exceptions
+                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 여기서 사용!
+            )
             .logout(logout -> logout
                     .logoutUrl("/api/auth/logout")
                     .addLogoutHandler(customOAuth2LogoutHandler)

--- a/src/main/java/com/dnd/sub/global/security/handler/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/dnd/sub/global/security/handler/CustomLogoutSuccessHandler.java
@@ -1,0 +1,37 @@
+package com.dnd.sub.global.security.handler;
+
+import com.dnd.sub.domain.auth.dto.response.AuthSuccessCode;
+import com.dnd.sub.global.dto.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, HttpServletResponse response,
+                                Authentication authentication) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        // ApiResponse 객체를 JSON으로 변환
+        ApiResponse<Void> apiResponse = ApiResponse.success(AuthSuccessCode.LOGOUT_OK);
+        String jsonResponse = objectMapper.writeValueAsString(apiResponse);
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/dnd/sub/global/security/handler/CustomOAuth2LogoutHandler.java
+++ b/src/main/java/com/dnd/sub/global/security/handler/CustomOAuth2LogoutHandler.java
@@ -1,0 +1,52 @@
+package com.dnd.sub.global.security.handler;
+
+import com.dnd.sub.domain.auth.service.RefreshTokenService;
+import com.dnd.sub.domain.member.repository.MemberRepository;
+import com.dnd.sub.domain.member.service.MemberService;
+import com.dnd.sub.global.security.jwt.JwtProvider;
+import com.dnd.sub.global.util.CookieUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class CustomOAuth2LogoutHandler implements LogoutHandler {
+
+    private final MemberService memberService;
+    private final RefreshTokenService refreshTokenService;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+
+        String refreshToken = extractRefreshToken(request.getCookies());
+        Long memberId = jwtProvider.extractUserId(refreshToken);
+        refreshTokenService.removeRefreshByMemberId(memberId);
+
+        ResponseCookie cookie = CookieUtil.createCookie("refresh_token", "", 0);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.setHeader(HttpHeaders.AUTHORIZATION,"");
+    }
+
+    public String extractRefreshToken(Cookie[] cookies) {
+
+        if (cookies == null) {
+            return null;
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> "refresh_token".equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/dnd/sub/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dnd/sub/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,42 @@
+package com.dnd.sub.global.security.jwt;
+
+import com.dnd.sub.domain.auth.exception.TokenErrorCode;
+import com.dnd.sub.domain.auth.exception.TokenException;
+import com.dnd.sub.global.dto.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        TokenException tokenException = (TokenException) request.getAttribute("tokenException");
+
+        ApiResponse<Void> errorResponse;
+        if (tokenException != null) {
+            errorResponse = ApiResponse.fail(tokenException.getErrorCode());
+        } else {
+            errorResponse = ApiResponse.fail(TokenErrorCode.INVALID_TOKEN);
+        }
+
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.global.security.jwt;
 
+import com.dnd.sub.domain.auth.exception.TokenException;
 import com.dnd.sub.domain.member.exception.MemberErrorCode;
 import com.dnd.sub.domain.member.exception.MemberException;
 import com.dnd.sub.domain.member.repository.MemberRepository;
@@ -32,20 +33,23 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = parseBearerToken(request);
         if (StringUtils.hasText(token)) {
+            try {
+                Long memberId = jwtProvider.extractUserId(token);
 
-            Long memberId = jwtProvider.extractUserId(token);
-
-            memberRepository.findById(memberId)
+                memberRepository.findById(memberId)
                     .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-            Authentication authentication = new UsernamePasswordAuthenticationToken(
-                memberId, null, Collections.emptyList());
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        memberId, null, Collections.emptyList());
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (TokenException e) {
+                SecurityContextHolder.clearContext();
+            } catch (MemberException e) {
+                SecurityContextHolder.clearContext();
+            }
         }
         filterChain.doFilter(request, response);
-
-
     }
 
 
@@ -54,7 +58,6 @@ public class JwtFilter extends OncePerRequestFilter {
         if (Strings.isNotBlank(authorization) && authorization.startsWith("Bearer ")) {
             return authorization.substring(7);
         }
-
         return null;
     }
 


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #41 


### 📝 작업 내용
- 간단한 로그아웃을 구현하였습니다. 카카오 로그아웃은 mvp 끝나고 추가하겠습니다!!

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added logout endpoint that invalidates tokens, clears the refresh token cookie, and returns a success response.

- Improvements
  - Standardized JSON responses for unauthorized/JWT errors, providing clear messages and consistent formatting.
  - Unified success response for token reissue with more specific authentication success messaging.

- Bug Fixes
  - Improved token error handling to reliably clear authentication context and return proper 401 responses on invalid or expired tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->