### PR TITLE
api 명세 업데이트 반영 및 검증 로직 추가

### DIFF
--- a/src/main/java/com/dnd/sub/DndApplication.java
+++ b/src/main/java/com/dnd/sub/DndApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
-@EnableJpaAuditing
+@EnableScheduling
 @ConfigurationPropertiesScan
+@EnableJpaAuditing
+@SpringBootApplication
 public class DndApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDto.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDto.java
@@ -14,6 +14,6 @@ public record GetMySubscriptionDto(
     int price,
     boolean isFavorites,
     String imageUrl,
-    LocalDate nextDueDay
+    LocalDate startedAt
 ) {
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/SaveSubscriptionDto.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/SaveSubscriptionDto.java
@@ -9,7 +9,7 @@ public record SaveSubscriptionDto(
     Long productId,
     Long planId,
     PayCycleUnitType payCycleUnit,
-    LocalDate startDay,
+    LocalDate startedAt,
     Long paymentMethodId,
     String memo,
     int participantCount
@@ -20,7 +20,7 @@ public record SaveSubscriptionDto(
             request.productId(),
             request.planId(),
             request.payCycleUnit(),
-            request.startDay(),
+            request.startedAt(),
             request.paymentMethodId(),
             request.memo(),
             request.participantCount()

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/request/SaveSubscriptionRequest.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/request/SaveSubscriptionRequest.java
@@ -8,7 +8,7 @@ public record SaveSubscriptionRequest(
     Long productId,
     Long planId,
     PayCycleUnitType payCycleUnit,
-    LocalDate startDay,
+    LocalDate startedAt,
     Long paymentMethodId,
     String memo,
     int participantCount

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -82,7 +82,7 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                     sub.getId(),
                     prod.getName(),
                     price,
-                    sub.getNextPaymentDay()
+                    sub.getStartedAt()
             );
         }).toList();
     }

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -82,7 +82,7 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                     sub.getId(),
                     prod.getName(),
                     price,
-                    sub.getStartedAt()
+                    sub.getNextPaymentDay()
             );
         }).toList();
     }
@@ -192,8 +192,8 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                 planName,
                 price,
                 sub.isFavorite(),
-                    prod.getImageUrl(),
-                    sub.getNextPaymentDay()
+                prod.getImageUrl(),
+                sub.getStartedAt()
             );
         }).toList();
 

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionRepository.java
@@ -3,7 +3,12 @@ package com.dnd.sub.domain.subscription.repository;
 import com.dnd.sub.domain.subscription.entity.Subscription;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, SubscriptionQueryRepository {
 
-    boolean existsByMemberIdAndId(Long memberId, Long subscriptionId);
+    boolean existsByIdAndMember_Id(Long subscriptionId, Long memberId);
+
+    List<Subscription> findByNextPaymentDayBefore(LocalDate today);
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -49,7 +49,8 @@ public class SubscriptionService {
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
     @Transactional
     public void updatePaymentDay() {
-        List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDayBefore(LocalDate.now(ZoneId.of("Asia/Seoul")));
+        final LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDayBefore(today);
 
         for (Subscription sub : subscriptions) {
             LocalDate oldNextPaymentDay = sub.getNextPaymentDay();

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -24,10 +24,12 @@ import com.dnd.sub.domain.subscription.repository.SubscriptionRepository;
 import com.dnd.sub.global.util.PaymentCycleUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 
 import static com.dnd.sub.domain.subscription.exception.SubscriptionErrorCode.MEMBER_SUBSCRIPTION_NOT_FOUND;
@@ -44,15 +46,31 @@ public class SubscriptionService {
     private final ProductRepository productRepository;
     private final PaymentMethodRepository paymentMethodRepository;
 
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @Transactional
+    public void updatePaymentDay() {
+        List<Subscription> subscriptions = subscriptionRepository.findByNextPaymentDayBefore(LocalDate.now(ZoneId.of("Asia/Seoul")));
+
+        for (Subscription sub : subscriptions) {
+            LocalDate oldNextPaymentDay = sub.getNextPaymentDay();
+            sub.updatePreviousPaymentDay(oldNextPaymentDay);
+
+            LocalDate newNextPaymentDay = PaymentCycleUtil.nextPaymentDay(oldNextPaymentDay, sub.getStartedAt(), sub.getPayCycleUnit());
+            sub.updateNextPaymentDay(newNextPaymentDay);
+        }
+    }
+
     @Transactional
     public void saveSubscription(final Long memberId, final SaveSubscriptionDto dto) {
         final Member member = getMember(memberId);
         final Product product = getProduct(dto.productId());
         final PaymentMethod paymentMethod = getPaymentMethod(dto.paymentMethodId());
 
+        final LocalDate previousPaymentDay = PaymentCycleUtil.previousPaymentDay(dto.startedAt(), dto.payCycleUnit());
+
         final LocalDate nextPaymentDay = PaymentCycleUtil.nextPaymentDay(
-            dto.startDay(),
-            dto.startDay(),
+            dto.startedAt(),
+            dto.startedAt(),
             dto.payCycleUnit()
         );
 
@@ -61,7 +79,8 @@ public class SubscriptionService {
             .product(product)
             .paymentMethod(paymentMethod)
             .planId(dto.planId())
-            .startedAt(dto.startDay())
+            .startedAt(dto.startedAt())
+            .previousPaymentDay(previousPaymentDay)
             .nextPaymentDay(nextPaymentDay)
             .participantCount(dto.participantCount())
             .payCycleUnit(dto.payCycleUnit())
@@ -125,7 +144,7 @@ public class SubscriptionService {
     }
 
     private void validateMemberSubscription(final Long memberId, final Long subscriptionId) {
-        if(!subscriptionRepository.existsByMemberIdAndId(memberId, subscriptionId)) {
+        if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
             throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);
         }
     }

--- a/src/main/java/com/dnd/sub/global/util/PaymentCycleUtil.java
+++ b/src/main/java/com/dnd/sub/global/util/PaymentCycleUtil.java
@@ -6,45 +6,81 @@ import com.dnd.sub.domain.subscription.exception.PayCycleException;
 import lombok.experimental.UtilityClass;
 
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 
 @UtilityClass
 public class PaymentCycleUtil {
 
-    //다음 결제일 date는 현재 다음 결제예정일, startDate는 최초 예정일
-    public static LocalDate nextPaymentDay(LocalDate date, LocalDate startDate, PayCycleUnitType cycleUnit) {
+    public static LocalDate previousPaymentDay(LocalDate startedAt, PayCycleUnitType cycleUnit) {
+        LocalDate now = LocalDate.now();
+
         switch (cycleUnit) {
             case WEEK:
-                return date.plusWeeks(1);
+                if (startedAt.isAfter(now.minusWeeks(1))) {
+                    return startedAt;
+                }
+
+                final long weeks = ChronoUnit.WEEKS.between(startedAt, now);
+
+                return startedAt.plusWeeks(weeks);
+
             case MONTH:
-                return addMonths(date, startDate, 1);
+                if (startedAt.isAfter(now.minusMonths(1))) {
+                    return startedAt;
+                }
+
+                final long months = ChronoUnit.MONTHS.between(startedAt, now);
+
+                return addMonths(startedAt.plusMonths(months), startedAt, -1);
+
             case YEAR:
-                return addYears(date, startDate, 1);
+                if (startedAt.isAfter(now.minusYears(1))) {
+                    return startedAt;
+                }
+
+                final long years = ChronoUnit.YEARS.between(startedAt, now);
+
+                return addYears(startedAt.plusYears(years), startedAt, -1);
+
+            default:
+                throw new PayCycleException(PayCycleErrorCode.CYCLE_TYPE_ERROR);
+        }
+    }
+
+    public static LocalDate nextPaymentDay(LocalDate previousPaymentDay, LocalDate startedAt, PayCycleUnitType cycleUnit) {
+        switch (cycleUnit) {
+            case WEEK:
+                return previousPaymentDay.plusWeeks(1);
+            case MONTH:
+                return addMonths(previousPaymentDay, startedAt, 1);
+            case YEAR:
+                return addYears(previousPaymentDay, startedAt, 1);
             default:
                 throw new PayCycleException(PayCycleErrorCode.CYCLE_TYPE_ERROR);
         }
     }
 
     //말일 조정 떄문에 plusMonths 못씀 말일 조정하는 함수
-    private static LocalDate addMonths(LocalDate date, LocalDate startDate, int months) {
-        int day = startDate.getDayOfMonth();
-        LocalDate nextDate = date.plusMonths(months);
-        return nextDate.withDayOfMonth(Math.min(day, nextDate.lengthOfMonth()));
+    private static LocalDate addMonths(LocalDate previousPaymentDay, LocalDate startedAt, int months) {
+        int startDayOfMonth = startedAt.getDayOfMonth();
+        LocalDate nextPaymentDay = previousPaymentDay.plusMonths(months);
+        return nextPaymentDay.withDayOfMonth(Math.min(startDayOfMonth, nextPaymentDay.lengthOfMonth()));
     }
 
     //윤년 조정
-    private static LocalDate addYears(LocalDate date, LocalDate startDate, int years) {
+    private static LocalDate addYears(LocalDate previousPaymentDay, LocalDate startedAt, int years) {
 
-        int nextYear = date.getYear() + years;
-        boolean isFeb29 = (startDate.getMonthValue() == 2 && startDate.getDayOfMonth() == 29);
+        int nextPaymentYear = previousPaymentDay.getYear() + years;
+        boolean isFeb29 = (startedAt.getMonthValue() == 2 && startedAt.getDayOfMonth() == 29);
 
-        if (date.getMonthValue() == 2 && isFeb29) {
+        if (previousPaymentDay.getMonthValue() == 2 && isFeb29) {
 
-            if (date.isLeapYear()) {
-                return LocalDate.of(nextYear, 2, 29);
+            if (previousPaymentDay.isLeapYear()) {
+                return LocalDate.of(nextPaymentYear, 2, 29);
             }
-            return LocalDate.of(nextYear, 2, 28);
+            return LocalDate.of(nextPaymentYear, 2, 28);
         }
 
-        return date.plusYears(years);
+        return previousPaymentDay.plusYears(years);
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #45

### 📝 작업 내용
- 내 구독 서비스 전체 조회 API 수정
    - startedAt 필드 추가
    - nextDueDay 필드 제거
- 즐겨찾는 정기 결제 서비스 전체 조회 API 수정
    - startedAt 필드 추가
    - nextDueDay 필드 제거
- 구독 등록 API 수정
    - startDay 필드명 startedAt으로 수정
- SubscriptionRepository jpa 메서드 네이밍 수정
    - existsByIdAndMember_Id로 수정
- 다음 결제일이 오늘보다 이전일 경우 결제일 업데이트 로직 추가
    - 스케줄링을 사용하여 구현

### 📢 참고 사항
https://dev-coco.tistory.com/176


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Daily scheduled job to roll forward overdue subscriptions’ next payment date; previous payment date is now tracked and available.
- Bug Fixes
  - Improved payment-cycle calculations (month-end handling and leap-year/Feb 29 correctness) for more accurate next/previous dates.
- Refactor
  - Unified date terminology: startDay → startedAt across APIs and internal flows; related membership lookup signature updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->