### PR TITLE
Feat/#58 구독 해지링크 조회 구현

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -150,6 +150,9 @@ jobs:
           AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
           EOF
+          
+          # front uri
+          FRONT_REDIRECT_URI=${{ secrets.FRONT_REDIRECT_URI }}
 
       - name: Start new server application
         id: start-new-server-application

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,10 +149,12 @@ jobs:
           AWS_REGION=${{ secrets.AWS_REGION }}
           AWS_ACCESS_KEY=${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_KEY=${{ secrets.AWS_SECRET_KEY }}
-          EOF
           
           # front uri
-          FRONT_REDIRECT_URI=${{ secrets.FRONT_REDIRECT_URI }}
+          FRONT_REDIRECT_URI=${{ secrets.FRONT_REDIRECT_URI }}    
+          EOF
+          
+         
 
       - name: Start new server application
         id: start-new-server-application

--- a/src/main/java/com/dnd/sub/developer/controller/DeveloperController.java
+++ b/src/main/java/com/dnd/sub/developer/controller/DeveloperController.java
@@ -9,12 +9,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Profile("local")
 public class DeveloperController {
 
     private final JwtProvider jwtProvider;
 
     //local 환경에서 테스트 시에만 사용
-    @Profile("local")
     @GetMapping("/api-test/member/{memberId}")
     public String generateJwtToken(@PathVariable Long memberId) {
         return jwtProvider.generateToken(memberId);

--- a/src/main/java/com/dnd/sub/domain/paymentmethod/controller/PaymentMethodControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/paymentmethod/controller/PaymentMethodControllerDocs.java
@@ -1,0 +1,27 @@
+package com.dnd.sub.domain.paymentmethod.controller;
+
+import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
+import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
+import com.dnd.sub.domain.paymentmethod.dto.GetAllPaymentMethodsDto;
+import com.dnd.sub.domain.paymentmethod.dto.response.GetAllPaymentMethodsResponse;
+import com.dnd.sub.global.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+
+@Tag(name = "결제수단 API", description = "결제수단과 관련한 API입니다.")
+public interface PaymentMethodControllerDocs {
+
+    @Operation(
+        summary = "결제 수단조회",
+        description = "결제수단을 조회합니다."
+    )
+    @GetMapping
+    public ApiResponse<GetAllPaymentMethodsResponse> getAllPaymentMethods();
+}
+

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -11,7 +11,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    List<Product> findAllByCategory(ProductCategoryType category);
+    @Query("""
+    SELECT p
+    FROM Product p
+    WHERE p.isAdminWritten = true
+      AND (:category IS NULL OR p.category = :category)
+    """)
+    List<Product> findAllByCategoryAndIsAdminWritten(ProductCategoryType category);
 
     @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
     Optional<Product> findBySubscriptionId(@Param("subscriptionId") Long subscriptionId);

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -42,6 +42,22 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     );
     List<Product> findAllByCategory(ProductCategoryType category);
 
+    @Query("""
+    SELECT p
+    FROM Product p
+    WHERE p.category = :category
+      AND p.id NOT IN (
+          SELECT s.product.id
+          FROM Subscription s
+          WHERE s.member.id = :memberId
+      )
+    ORDER BY function('RAND')
+    """)
+    List<Product> findRandomProductsByCategoryExcludingSubscribed(
+        @Param("memberId") Long memberId,
+        @Param("category") ProductCategoryType category,
+        Pageable pageable
+    );
     @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
     Optional<Product> findBySubscriptionId(@Param("subscriptionId") Long subscriptionId);
 

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -3,9 +3,14 @@ package com.dnd.sub.domain.product.repository;
 import com.dnd.sub.domain.product.entity.Product;
 import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByCategory(ProductCategoryType category);
+
+    @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
+    Optional<Product> findBySubscriptionId(Long subscriptionId);
 }

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -4,6 +4,7 @@ import com.dnd.sub.domain.product.entity.Product;
 import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,5 +13,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByCategory(ProductCategoryType category);
 
     @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
-    Optional<Product> findBySubscriptionId(Long subscriptionId);
+    Optional<Product> findBySubscriptionId(@Param("subscriptionId") Long subscriptionId);
 }

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -42,5 +43,5 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     List<Product> findAllByCategory(ProductCategoryType category);
 
     @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
-    Optional<Product> findBySubscriptionId(Long subscriptionId);
+    Optional<Product> findBySubscriptionId(@Param("subscriptionId") Long subscriptionId);
 }

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -44,4 +44,7 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
 
     @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
     Optional<Product> findBySubscriptionId(@Param("subscriptionId") Long subscriptionId);
+
+    @Query("SELECT p FROM Product p WHERE p.category = :category ORDER BY function('RAND')")
+    List<Product> findRandomProductsByCategory(@Param("category") ProductCategoryType category, Pageable pageable);
 }

--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,4 +39,8 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
         @Param("category") ProductCategoryType category,
         Pageable pageable
     );
+    List<Product> findAllByCategory(ProductCategoryType category);
+
+    @Query("SELECT s.product FROM Subscription s WHERE s.id = :subscriptionId")
+    Optional<Product> findBySubscriptionId(Long subscriptionId);
 }

--- a/src/main/java/com/dnd/sub/domain/product/service/ProductService.java
+++ b/src/main/java/com/dnd/sub/domain/product/service/ProductService.java
@@ -27,7 +27,7 @@ public class ProductService {
     private final ProductPlanRepository productPlanRepository;
 
     public List<GetProductDto> getAllProducts(ProductCategoryType category) {
-        List<Product> products = productRepository.findAllByCategory(category);
+        List<Product> products = productRepository.findAllByCategoryAndIsAdminWritten(category);
 
         return products.stream().map(p -> {
             List<ProductPlan> productPlans = productPlanRepository.findAllByProductId(p.getId());

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -103,7 +103,7 @@ public class SubscriptionController implements SubscriptionControllerDocs {
 
     @GetMapping("/{subscriptionsId}/unsubscription")
     public ApiResponse<GetUnsubscribeUrlResponse> getUnsubscribeUrl(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionsId){
-        GetUnsubscribeUrlResponse response = subscriptionService.getUnsubscribeUrl(subscriptionsId);
+        GetUnsubscribeUrlResponse response = subscriptionService.getUnsubscribeUrl(memberId, subscriptionsId);
 
         return ApiResponse.success(GET_UNSUBSCRIBE_URL, response);
     }

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -10,6 +10,7 @@ import com.dnd.sub.domain.subscription.dto.request.SaveSubscriptionRequest;
 import com.dnd.sub.domain.subscription.dto.response.GetMySubscriptionsResponse;
 import com.dnd.sub.domain.subscription.dto.response.GetPaymentSoonResponse;
 import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
+import com.dnd.sub.domain.subscription.dto.response.GetUnsubscribeUrlResponse;
 import com.dnd.sub.domain.subscription.service.SubscriptionService;
 import com.dnd.sub.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -98,5 +99,12 @@ public class SubscriptionController implements SubscriptionControllerDocs {
         subscriptionService.updateIsFavorite(memberId, subscriptionId);
 
         return ApiResponse.success(UPDATE_IS_FAVORITE);
+    }
+
+    @GetMapping("/{subscriptionsId}/unsubscription")
+    public ApiResponse<GetUnsubscribeUrlResponse> getUnsubscribeUrl(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionsId){
+        GetUnsubscribeUrlResponse response = subscriptionService.getUnsubscribeUrl(subscriptionsId);
+
+        return ApiResponse.success(GET_UNSUBSCRIBE_URL, response);
     }
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
@@ -4,10 +4,9 @@ import com.dnd.sub.domain.product.entity.ProductCategoryType;
 import com.dnd.sub.domain.subscription.dto.GetMySubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
 import com.dnd.sub.domain.subscription.dto.SaveSubscriptionDto;
+import com.dnd.sub.domain.subscription.dto.request.SaveCustomSubscriptionRequest;
 import com.dnd.sub.domain.subscription.dto.request.SaveSubscriptionRequest;
-import com.dnd.sub.domain.subscription.dto.response.GetMySubscriptionsResponse;
-import com.dnd.sub.domain.subscription.dto.response.GetPaymentSoonResponse;
-import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
+import com.dnd.sub.domain.subscription.dto.response.*;
 import com.dnd.sub.global.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -15,6 +14,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import static com.dnd.sub.domain.subscription.dto.response.SubscriptionSuccessCode.GET_UNSUBSCRIBE_URL;
 
 
 @Tag(name = "사용자 구독 API", description = "사용자 구독과 관련한 API입니다.")
@@ -41,6 +42,14 @@ public interface SubscriptionControllerDocs {
     );
 
     @Operation(
+        summary = "커스텀 구독 등록",
+        description = "커스텀 구독을 등록 합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @PostMapping("/custom")
+    public ApiResponse<Void> saveCustomSubscription(@AuthenticationPrincipal Long memberId, @RequestBody SaveCustomSubscriptionRequest request);
+
+    @Operation(
             summary = "즐겨찾는 정기 결제 서비스 전체 조회",
             description = "즐겨찾기한 구독을 조회합니다.",
             security = @SecurityRequirement(name = "Bearer Authentication")
@@ -51,6 +60,14 @@ public interface SubscriptionControllerDocs {
             @RequestParam(required = false) ProductCategoryType category,
             @RequestParam(required = false) SubscriptionSortType sort
     );
+
+    @Operation(
+        summary = "내 구독 상세 정보",
+        description = "내구독 상세 정보를 조회합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @GetMapping("/{subscriptionId}")
+    public ApiResponse<GetMySubscriptionDetailInfoResponse> getMySubscriptionDetailInfo(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId);
 
     @Operation(
             summary = "결제 임박한 정기 결제 서비스 조회",
@@ -75,4 +92,14 @@ public interface SubscriptionControllerDocs {
     )
     @PatchMapping("/{subscriptionId}/favorite")
     public ApiResponse<Void> updateIsFavorite(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId);
+
+    @Operation(
+        summary = "구독 해지 링크 조회 api",
+        description = "구독 해지 링크를 조회합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+
+    @GetMapping("/{subscriptionsId}/unsubscription")
+    public ApiResponse<GetUnsubscribeUrlResponse> getUnsubscribeUrl(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionsId);
+
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
@@ -98,7 +98,6 @@ public interface SubscriptionControllerDocs {
         description = "구독 해지 링크를 조회합니다.",
         security = @SecurityRequirement(name = "Bearer Authentication")
     )
-
     @GetMapping("/{subscriptionsId}/unsubscription")
     public ApiResponse<GetUnsubscribeUrlResponse> getUnsubscribeUrl(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionsId);
 

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetUnsubscribeUrlResponse.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetUnsubscribeUrlResponse.java
@@ -1,0 +1,6 @@
+package com.dnd.sub.domain.subscription.dto.response;
+
+public record GetUnsubscribeUrlResponse(
+    String unsubscribeUrl
+) {
+}

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
@@ -14,6 +14,7 @@ public enum SubscriptionSuccessCode implements SuccessCode {
     SAVE_SUBSCRIPTION(HttpStatus.CREATED.value(), "SS-204", "구독 등록 성공"),
     UPDATE_IS_FAVORITE(HttpStatus.OK.value(), "SS-205", "즐겨찾기 추가/해지 성공"),
     SAVE_CUSTOM_SUBSCRIPTION(HttpStatus.CREATED.value(), "SS-206", "커스텀 구독 등록 성공"),
+    GET_UNSUBSCRIBE_URL(HttpStatus.OK.value(), "SS-208", "해지 링크 조회 성공"),
     GET_PAYMENT_TOTAL(HttpStatus.OK.value(), "SS-211", "월간 결제 요약 조회 성공"),
     ;
 

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionQueryRepositoryImpl.java
@@ -99,8 +99,7 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
                 .join(s.member, m)
                 .join(s.product, p)
                 .leftJoin(pp).on(pp.id.eq(s.planId))
-                .where(s.member.id.eq(memberId)
-                        .and(s.startedAt.isNotNull()))
+                .where(s.member.id.eq(memberId))
                 .fetch();
 
         if (tuples.isEmpty()) {
@@ -121,6 +120,9 @@ public class SubscriptionQueryRepositoryImpl implements SubscriptionQueryReposit
             Subscription sub = tuple.get(s);
             Integer price = tuple.get(pp.price);
 
+            if(sub.getStartedAt() == null){
+                continue;
+            }
             LocalDate prevPayDay = sub.getPreviousPaymentDay();
             LocalDate nextPayDay = sub.getNextPaymentDay();
 

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -194,7 +194,9 @@ public class SubscriptionService {
         subscription.updateIsFavorite();
     }
 
-    public GetUnsubscribeUrlResponse getUnsubscribeUrl(final Long subscriptionId) {
+    public GetUnsubscribeUrlResponse getUnsubscribeUrl(final Long memberId, final Long subscriptionId) {
+        validateMemberSubscription(memberId, subscriptionId);
+
         String unsubscribeUrl = getProductBySubscriptionId(subscriptionId).getUnsubscribeUrl();
         return new GetUnsubscribeUrlResponse(unsubscribeUrl);
     }

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -215,10 +215,6 @@ public class SubscriptionService {
             .orElseThrow(() -> new SubscriptionException(SUBSCRIPTION_NOT_FOUND));
     }
 
-    private Product getProductBySubscriptionId(final Long subscriptionId) {
-        return productRepository.findBySubscriptionId(subscriptionId)
-            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
-
     public GetMySubscriptionDetailInfoDto getMySubscriptionDetailInfo(final Long memberId, final Long subscriptionId) {
         validateMemberSubscription(memberId, subscriptionId);
 

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -132,6 +132,8 @@ public class SubscriptionService {
             .unsubscribeUrl(null)
             .build();
 
+        productRepository.save(product);
+
         ProductPlan productPlan = ProductPlan.builder()
             .product(product)
             .name(null)
@@ -139,11 +141,13 @@ public class SubscriptionService {
             .benefit(null)
             .build();
 
+        productPlanRepository.save(productPlan);
+
         Subscription subscription = Subscription.builder()
             .member(member)
             .product(product)
             .paymentMethod(paymentMethod)
-            .planId(null)
+            .planId(productPlan.getId())
             .startedAt(dto.startedAt())
             .previousPaymentDay(previousPaymentDay)
             .nextPaymentDay(nextPaymentDay)
@@ -152,8 +156,6 @@ public class SubscriptionService {
             .memo(dto.memo())
             .build();
 
-        productRepository.save(product);
-        productPlanRepository.save(productPlan);
         subscriptionRepository.save(subscription);
     }
 

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -21,6 +21,7 @@ import com.dnd.sub.domain.subscription.dto.GetPaymentSoonDto;
 import com.dnd.sub.domain.subscription.dto.SaveCustomSubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.SaveSubscriptionDto;
 import com.dnd.sub.domain.subscription.dto.response.GetPaymentTotalResponse;
+import com.dnd.sub.domain.subscription.dto.response.GetUnsubscribeUrlResponse;
 import com.dnd.sub.domain.subscription.entity.Subscription;
 import com.dnd.sub.domain.subscription.exception.SubscriptionException;
 import com.dnd.sub.domain.subscription.repository.SubscriptionRepository;
@@ -193,6 +194,11 @@ public class SubscriptionService {
         subscription.updateIsFavorite();
     }
 
+    public GetUnsubscribeUrlResponse getUnsubscribeUrl(final Long subscriptionId) {
+        String unsubscribeUrl = getProductBySubscriptionId(subscriptionId).getUnsubscribeUrl();
+        return new GetUnsubscribeUrlResponse(unsubscribeUrl);
+    }
+
     private void validateMemberSubscription(final Long memberId, final Long subscriptionId) {
         if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
             throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);
@@ -202,5 +208,10 @@ public class SubscriptionService {
     private Subscription getSubscription(final Long subscriptionId) {
         return subscriptionRepository.findById(subscriptionId)
             .orElseThrow(() -> new SubscriptionException(SUBSCRIPTION_NOT_FOUND));
+    }
+
+    private Product getProductBySubscriptionId(final Long subscriptionId) {
+        return productRepository.findBySubscriptionId(subscriptionId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -243,4 +243,9 @@ public class SubscriptionService {
             subscription.isFavorite()
         );
     }
+
+    private Product getProductBySubscriptionId(final Long subscriptionId) {
+        return productRepository.findBySubscriptionId(subscriptionId)
+            .orElseThrow(() -> new ProductException(ProductErrorCode.PRODUCT_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -1,31 +1,31 @@
-  package com.dnd.sub.global.config;
+package com.dnd.sub.global.config;
 
-  import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
-  import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
-  import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
-  import com.dnd.sub.global.security.handler.CustomSuccessHandler;
-  import com.dnd.sub.global.security.jwt.JwtAuthenticationEntryPoint;
-  import com.dnd.sub.global.security.jwt.JwtFilter;
-  import java.util.List;
+import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
+import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
+import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
+import com.dnd.sub.global.security.handler.CustomSuccessHandler;
+import com.dnd.sub.global.security.jwt.JwtAuthenticationEntryPoint;
+import com.dnd.sub.global.security.jwt.JwtFilter;
+import java.util.List;
 
-  import lombok.RequiredArgsConstructor;
-  import org.springframework.context.annotation.Bean;
-  import org.springframework.context.annotation.Configuration;
-  import org.springframework.http.HttpMethod;
-  import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-  import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-  import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-  import org.springframework.security.config.http.SessionCreationPolicy;
-  import org.springframework.security.web.SecurityFilterChain;
-  import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-  import org.springframework.web.cors.CorsConfiguration;
-  import org.springframework.web.cors.CorsConfigurationSource;
-  import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-  @Configuration
-  @RequiredArgsConstructor
-  @EnableWebSecurity
-  public class SecurityConfig {
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
 
     private final CustomOAuth2LogoutHandler customOAuth2LogoutHandler;
     private final CustomOAuth2UserService customOAuth2UserService;
@@ -36,7 +36,7 @@
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2LogoutHandler customOAuth2LogoutHandler) throws Exception {
-      http
+        http
           .cors(cors -> cors.configurationSource(configurationSource()))
           .csrf(AbstractHttpConfigurer::disable)
           .formLogin(AbstractHttpConfigurer::disable)
@@ -82,4 +82,4 @@
       source.registerCorsConfiguration("/**", configuration);
       return source;
     }
-  }
+}

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -67,7 +67,7 @@ public class SecurityConfig {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(List.of(    "http://localhost:3000",
         "http://localhost:5173"));
-    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+    configuration.setAllowedMethods(List.of("*"));
     configuration.setAllowedHeaders(List.of("*"));
     configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
     configuration.setAllowCredentials(true);

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -1,79 +1,83 @@
-package com.dnd.sub.global.config;
+  package com.dnd.sub.global.config;
 
-import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
-import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
-import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
-import com.dnd.sub.global.security.handler.CustomSuccessHandler;
-import com.dnd.sub.global.security.jwt.JwtAuthenticationEntryPoint;
-import com.dnd.sub.global.security.jwt.JwtFilter;
-import java.util.List;
+  import com.dnd.sub.global.security.custom.CustomOAuth2UserService;
+  import com.dnd.sub.global.security.handler.CustomLogoutSuccessHandler;
+  import com.dnd.sub.global.security.handler.CustomOAuth2LogoutHandler;
+  import com.dnd.sub.global.security.handler.CustomSuccessHandler;
+  import com.dnd.sub.global.security.jwt.JwtAuthenticationEntryPoint;
+  import com.dnd.sub.global.security.jwt.JwtFilter;
+  import java.util.List;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+  import lombok.RequiredArgsConstructor;
+  import org.springframework.context.annotation.Bean;
+  import org.springframework.context.annotation.Configuration;
+  import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+  import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+  import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+  import org.springframework.security.config.http.SessionCreationPolicy;
+  import org.springframework.security.web.SecurityFilterChain;
+  import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+  import org.springframework.web.cors.CorsConfiguration;
+  import org.springframework.web.cors.CorsConfigurationSource;
+  import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-@Configuration
-@RequiredArgsConstructor
-@EnableWebSecurity
-public class SecurityConfig {
+  @Configuration
+  @RequiredArgsConstructor
+  @EnableWebSecurity
+  public class SecurityConfig {
 
-  private final CustomOAuth2LogoutHandler customOAuth2LogoutHandler;
-  private final CustomOAuth2UserService customOAuth2UserService;
-  private final CustomSuccessHandler customSuccessHandler;
-  private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-  private final JwtFilter jwtFilter;
-  private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
+    private final CustomOAuth2LogoutHandler customOAuth2LogoutHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtFilter jwtFilter;
+    private final CustomLogoutSuccessHandler customLogoutSuccessHandler;
 
-  @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2LogoutHandler customOAuth2LogoutHandler) throws Exception {
-    http
-        .cors(cors -> cors.configurationSource(configurationSource()))
-        .csrf(AbstractHttpConfigurer::disable)
-        .formLogin(AbstractHttpConfigurer::disable)
-        .httpBasic(AbstractHttpConfigurer::disable)
-        .oauth2Login((oauth2) -> oauth2
-                .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
-                .userService(customOAuth2UserService))
-                .successHandler(customSuccessHandler))
-        .sessionManagement(s -> s.sessionCreationPolicy((SessionCreationPolicy.STATELESS)))
-            .exceptionHandling(exceptions -> exceptions
-                    .authenticationEntryPoint(jwtAuthenticationEntryPoint)  // 여기서 사용!
-            )
-            .logout(logout -> logout
-                    .logoutUrl("/api/auth/logout")
-                    .addLogoutHandler(customOAuth2LogoutHandler)
-                    .deleteCookies("refresh_token")
-                    .logoutSuccessHandler(customLogoutSuccessHandler)
-            )
-        .authorizeHttpRequests(
-                a -> a.anyRequest().permitAll() //일단 다 허용
-        )
-        .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CustomOAuth2LogoutHandler customOAuth2LogoutHandler) throws Exception {
+      http
+          .cors(cors -> cors.configurationSource(configurationSource()))
+          .csrf(AbstractHttpConfigurer::disable)
+          .formLogin(AbstractHttpConfigurer::disable)
+          .httpBasic(AbstractHttpConfigurer::disable)
+          .oauth2Login((oauth2) -> oauth2
+                  .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                  .userService(customOAuth2UserService))
+                  .successHandler(customSuccessHandler))
+          .sessionManagement(s -> s.sessionCreationPolicy((SessionCreationPolicy.STATELESS)))
+              .exceptionHandling(exceptions -> exceptions
+                      .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+              )
+              .logout(logout -> logout
+                      .logoutUrl("/api/auth/logout")
+                      .addLogoutHandler(customOAuth2LogoutHandler)
+                      .deleteCookies("refresh_token")
+                      .logoutSuccessHandler(customLogoutSuccessHandler)
+              )
+          .authorizeHttpRequests(
+                  a ->
+                      a.requestMatchers("/api/member/**",
+                              "/api/subscriptions/**",
+                              "/api/products/**").authenticated()
+              .anyRequest().permitAll() //일단 다 허용
+          )
+          .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
 
-    return http.build();
+      return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource configurationSource() {
+      CorsConfiguration configuration = new CorsConfiguration();
+      configuration.setAllowedOrigins(List.of(    "http://localhost:3000",
+          "http://localhost:5173"));
+      configuration.setAllowedMethods(List.of("*"));
+      configuration.setAllowedHeaders(List.of("*"));
+      configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
+      configuration.setAllowCredentials(true);
+
+      UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+      source.registerCorsConfiguration("/**", configuration);
+      return source;
+    }
   }
-
-  @Bean
-  public CorsConfigurationSource configurationSource() {
-    CorsConfiguration configuration = new CorsConfiguration();
-    configuration.setAllowedOrigins(List.of(    "http://localhost:3000",
-        "http://localhost:5173"));
-    configuration.setAllowedMethods(List.of("*"));
-    configuration.setAllowedHeaders(List.of("*"));
-    configuration.setExposedHeaders(List.of("Authorization", "Set-Cookie"));
-    configuration.setAllowCredentials(true);
-
-    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-    source.registerCorsConfiguration("/**", configuration);
-    return source;
-  }
-}

--- a/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/sub/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@
   import lombok.RequiredArgsConstructor;
   import org.springframework.context.annotation.Bean;
   import org.springframework.context.annotation.Configuration;
+  import org.springframework.http.HttpMethod;
   import org.springframework.security.config.annotation.web.builders.HttpSecurity;
   import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
   import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -55,10 +56,11 @@
                       .logoutSuccessHandler(customLogoutSuccessHandler)
               )
           .authorizeHttpRequests(
-                  a ->
-                      a.requestMatchers("/api/member/**",
-                              "/api/subscriptions/**",
-                              "/api/products/**").authenticated()
+              a ->
+                  a.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                      .requestMatchers("/api/member/**",
+                          "/api/subscriptions/**",
+                          "/api/products/**").authenticated()
               .anyRequest().permitAll() //일단 다 허용
           )
           .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/dnd/sub/global/properties/FrontUriProperties.java
+++ b/src/main/java/com/dnd/sub/global/properties/FrontUriProperties.java
@@ -1,0 +1,9 @@
+package com.dnd.sub.global.properties;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("front")
+public record FrontUriProperties(
+    String redirectUri
+) {
+}

--- a/src/main/java/com/dnd/sub/global/security/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/dnd/sub/global/security/handler/CustomSuccessHandler.java
@@ -3,6 +3,7 @@ package com.dnd.sub.global.security.handler;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 import com.dnd.sub.domain.auth.service.RefreshTokenService;
+import com.dnd.sub.global.properties.FrontUriProperties;
 import com.dnd.sub.global.security.custom.CustomOAuth2User;
 import com.dnd.sub.global.security.jwt.JwtProvider;
 import com.dnd.sub.global.util.CookieUtil;
@@ -25,6 +26,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
     private final JwtProvider jwtProvider;
     private final RefreshTokenService refreshTokenService;
+    private final FrontUriProperties frontUriProperties;
 
 
     @Override
@@ -48,7 +50,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         response.addHeader(AUTHORIZATION, "Bearer "+ accessToken);
         response.addHeader(HttpHeaders.SET_COOKIE, refreshCookie.toString());
 
-        response.sendRedirect("http://localhost:5173/subscriptions");
+        response.sendRedirect(frontUriProperties.redirectUri());
     }
 
 }

--- a/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.global.security.jwt;
 
+import com.dnd.sub.domain.auth.exception.TokenErrorCode;
 import com.dnd.sub.domain.auth.exception.TokenException;
 import com.dnd.sub.domain.member.exception.MemberErrorCode;
 import com.dnd.sub.domain.member.exception.MemberException;
@@ -38,6 +39,9 @@ public class JwtFilter extends OncePerRequestFilter {
             try {
                 Long memberId = jwtProvider.extractUserId(token);
 
+                if (memberId == null) {
+                    throw new TokenException(TokenErrorCode.INVALID_TOKEN);
+                }
                 memberRepository.findById(memberId)
                     .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 

--- a/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
+++ b/src/main/java/com/dnd/sub/global/security/jwt/JwtFilter.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.logging.log4j.util.Strings;
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -28,6 +29,7 @@ public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
     private final MemberRepository memberRepository;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 
     @Override
@@ -51,6 +53,8 @@ public class JwtFilter extends OncePerRequestFilter {
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (TokenException e) {
                 SecurityContextHolder.clearContext();
+                request.setAttribute("tokenException", e);
+                jwtAuthenticationEntryPoint.commence(request, response, new InsufficientAuthenticationException("Jwt 에러", e));
             } catch (MemberException e) {
                 SecurityContextHolder.clearContext();
             }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -31,4 +31,7 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-expiration: ${ACCESS_EXPIRATION}
-  refresh-expiration: ${REFRESH_EXPIRATION}
+  refresh-expiration: ${REFRESH_EXPIRATION
+
+front:
+  redirect-uri:${FRONT_REDIRECT_URI}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -39,3 +39,5 @@ jwt:
   secret: ${JWT_SECRET:testestsetstsetstetsetsetstsetsetset}
   access-expiration: ${ACCESS_EXPIRATION:3600000}
   refresh-expiration: ${REFRESH_EXPIRATION:86400000}
+front:
+  redirect-uri: http://localhost:5173/subscriptions


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #58 

### 📝 작업 내용
- 구독 해지 링크 조회를 구현하였습니다
- 토큰 검증 url을 추가하였습니다
- 내 요약에서 started_at이 null이면 개수를 count 하지 않는 것을 수정했습니다.

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added endpoint to retrieve an unsubscribe URL for a subscription.
  - Post-login redirect is now configurable via environment settings.

- Security
  - Authentication required for member, subscription, and product APIs.
  - Broader CORS method support.
  - Improved JWT error handling for invalid tokens.

- Bug Fixes
  - More accurate payment total calculations by skipping subscriptions without a start date.

- Documentation
  - Added/updated API docs for payment methods and subscriptions, including the unsubscribe URL endpoint.

- Chores
  - CI now injects the frontend redirect URI.
  - Local/dev configs include frontend redirect settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->