### PR TITLE
커스텀 구독 등록 시 planId를 저장하도록 로직 수정

### DIFF
--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -131,6 +131,8 @@ public class SubscriptionService {
             .unsubscribeUrl(null)
             .build();
 
+        productRepository.save(product);
+
         ProductPlan productPlan = ProductPlan.builder()
             .product(product)
             .name(null)
@@ -138,11 +140,13 @@ public class SubscriptionService {
             .benefit(null)
             .build();
 
+        productPlanRepository.save(productPlan);
+
         Subscription subscription = Subscription.builder()
             .member(member)
             .product(product)
             .paymentMethod(paymentMethod)
-            .planId(null)
+            .planId(productPlan.getId())
             .startedAt(dto.startedAt())
             .previousPaymentDay(previousPaymentDay)
             .nextPaymentDay(nextPaymentDay)
@@ -151,8 +155,6 @@ public class SubscriptionService {
             .memo(dto.memo())
             .build();
 
-        productRepository.save(product);
-        productPlanRepository.save(productPlan);
         subscriptionRepository.save(subscription);
     }
 


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #81

### 📝 작업 내용
- 커스텀 구독 등록 시 planId를 저장하도록 로직 수정

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * New subscriptions are now correctly linked to their selected plan.
  * Prevents null or missing plan references on newly created subscriptions.
  * Reduces errors during subscription creation and improves data integrity.
  * Resolves occasional issues where plan details failed to display for new subscribers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->