### PR TITLE
구독 서비스 전체 조회 시 커스텀 구독 등록 내역은 안보이도록 수정

### DIFF
--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductRepository.java
@@ -10,7 +10,13 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-    List<Product> findAllByCategory(ProductCategoryType category);
+    @Query("""
+    SELECT p
+    FROM Product p
+    WHERE p.isAdminWritten = true
+      AND (:category IS NULL OR p.category = :category)
+    """)
+    List<Product> findAllByCategoryAndIsAdminWritten(ProductCategoryType category);
 
     @Query("""
     SELECT p

--- a/src/main/java/com/dnd/sub/domain/product/service/ProductService.java
+++ b/src/main/java/com/dnd/sub/domain/product/service/ProductService.java
@@ -27,7 +27,7 @@ public class ProductService {
     private final ProductPlanRepository productPlanRepository;
 
     public List<GetProductDto> getAllProducts(ProductCategoryType category) {
-        List<Product> products = productRepository.findAllByCategory(category);
+        List<Product> products = productRepository.findAllByCategoryAndIsAdminWritten(category);
 
         return products.stream().map(p -> {
             List<ProductPlan> productPlans = productPlanRepository.findAllByProductId(p.getId());


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #83

### 📝 작업 내용
- 구독 서비스 전체 조회 시 커스텀 구독 등록 내역은 안보이도록 수정

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Product listings now display only admin-curated items, improving result quality and consistency.
  - Category filters continue to work as before; you may see fewer results due to curation.
  - No changes to the product details or pricing information shown in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->