### PR TITLE
구독삭제 구현

### DIFF
--- a/src/main/java/com/dnd/sub/domain/product/repository/ProductPlanRepository.java
+++ b/src/main/java/com/dnd/sub/domain/product/repository/ProductPlanRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface ProductPlanRepository extends JpaRepository<ProductPlan, Long> {
     List<ProductPlan> findAllByProductId(Long productId);
     ProductPlan findByProduct(Product product);
+    void deleteByProductId(Long productId);
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -111,7 +111,7 @@ public class SubscriptionController implements SubscriptionControllerDocs {
     }
 
 
-    @DeleteMapping("/{subscriptionId}")
+    @DeleteMapping("/{subscriptionId")
     public ApiResponse<Void> deleteSubscription(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId) {
         subscriptionService.deleteSubscription(memberId, subscriptionId);
 

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -18,15 +18,7 @@ import com.dnd.sub.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -116,5 +108,13 @@ public class SubscriptionController implements SubscriptionControllerDocs {
         GetUnsubscribeUrlResponse response = subscriptionService.getUnsubscribeUrl(memberId, subscriptionsId);
 
         return ApiResponse.success(GET_UNSUBSCRIBE_URL, response);
+    }
+
+
+    @DeleteMapping("/{subscriptionId}")
+    public ApiResponse<Void> deleteSubscription(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId) {
+        subscriptionService.deleteSubscription(memberId, subscriptionId);
+
+        return ApiResponse.success(DELETE_SUBSCRIBE);
     }
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionController.java
@@ -111,7 +111,7 @@ public class SubscriptionController implements SubscriptionControllerDocs {
     }
 
 
-    @DeleteMapping("/{subscriptionId")
+    @DeleteMapping("/{subscriptionId}")
     public ApiResponse<Void> deleteSubscription(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId) {
         subscriptionService.deleteSubscription(memberId, subscriptionId);
 

--- a/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/controller/SubscriptionControllerDocs.java
@@ -101,4 +101,11 @@ public interface SubscriptionControllerDocs {
     @GetMapping("/{subscriptionsId}/unsubscription")
     public ApiResponse<GetUnsubscribeUrlResponse> getUnsubscribeUrl(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionsId);
 
+    @Operation(
+        summary = "구독 삭제 api",
+        description = "구독을 삭제 합니다.",
+        security = @SecurityRequirement(name = "Bearer Authentication")
+    )
+    @DeleteMapping("/{subscriptionId}")
+    public ApiResponse<Void> deleteSubscription(@AuthenticationPrincipal Long memberId, @PathVariable Long subscriptionId);
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/SubscriptionSuccessCode.java
@@ -16,6 +16,7 @@ public enum SubscriptionSuccessCode implements SuccessCode {
     SAVE_CUSTOM_SUBSCRIPTION(HttpStatus.CREATED.value(), "SS-206", "커스텀 구독 등록 성공"),
     GET_MY_SUBSCRIPTION_DETAIL_INFO(HttpStatus.OK.value(), "SS-207", "내 구독 상세 정보 조회 성공"),
     GET_UNSUBSCRIBE_URL(HttpStatus.OK.value(), "SS-208", "해지 링크 조회 성공"),
+    DELETE_SUBSCRIBE(HttpStatus.OK.value(), "SS-209", "구독 삭제 성공"),
     GET_PAYMENT_TOTAL(HttpStatus.OK.value(), "SS-211", "월간 결제 요약 조회 성공"),
     ;
 

--- a/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionRepository.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/repository/SubscriptionRepository.java
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface SubscriptionRepository extends JpaRepository<Subscription, Long>, SubscriptionQueryRepository {
 
     boolean existsByIdAndMember_Id(Long subscriptionId, Long memberId);
 
     List<Subscription> findByNextPaymentDayBefore(LocalDate today);
+
+    Optional<Subscription> findByIdAndMember_Id(Long subscriptionId, Long memberId);
 }

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -221,9 +221,6 @@ public class SubscriptionService {
 
 
     private Subscription validateMemberSubscription(final Long memberId, final Long subscriptionId) {
-//        if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
-//            throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);
-//        }
         return subscriptionRepository.findByIdAndMember_Id(subscriptionId, memberId)
             .orElseThrow(() -> new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND));
     }

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -206,9 +206,7 @@ public class SubscriptionService {
 
     @Transactional
     public void deleteSubscription(final Long memberId, final Long subscriptionId) {
-        validateMemberSubscription(memberId, subscriptionId);
-
-        Subscription subscription = getSubscription(subscriptionId);
+        Subscription subscription = validateMemberSubscription(memberId, subscriptionId);
         Product product = subscription.getProduct();
 
         subscriptionRepository.delete(subscription);
@@ -220,10 +218,14 @@ public class SubscriptionService {
 
     }
 
-    private void validateMemberSubscription(final Long memberId, final Long subscriptionId) {
-        if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
-            throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);
-        }
+
+
+    private Subscription validateMemberSubscription(final Long memberId, final Long subscriptionId) {
+//        if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
+//            throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);
+//        }
+        return subscriptionRepository.findByIdAndMember_Id(subscriptionId, memberId)
+            .orElseThrow(() -> new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND));
     }
 
     private Subscription getSubscription(final Long subscriptionId) {

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -204,6 +204,22 @@ public class SubscriptionService {
         return new GetUnsubscribeUrlResponse(unsubscribeUrl);
     }
 
+    @Transactional
+    public void deleteSubscription(final Long memberId, final Long subscriptionId) {
+        validateMemberSubscription(memberId, subscriptionId);
+
+        Subscription subscription = getSubscription(subscriptionId);
+        Product product = subscription.getProduct();
+
+        subscriptionRepository.delete(subscription);
+
+        if(!product.isAdminWritten()){
+            productPlanRepository.deleteByProductId(product.getId());
+            productRepository.delete(product);
+        }
+
+    }
+
     private void validateMemberSubscription(final Long memberId, final Long subscriptionId) {
         if(!subscriptionRepository.existsByIdAndMember_Id(subscriptionId, memberId)) {
             throw new SubscriptionException(MEMBER_SUBSCRIPTION_NOT_FOUND);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 spring:
-  profiles.active: dev
+  profiles.active: local

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,2 @@
 spring:
-  profiles.active: local
+  profiles.active: dev


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #80 

### 📝 작업 내용
- 구독 삭제를 구현하였고 커스텀 구독일시 커스텀 프로덕트도 함께 삭제하도록 구현하였습니다!!

### 📢 참고 사항
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DELETE endpoint to remove a subscription; returns a success confirmation.
  * Subscription deletion is transactional and, when applicable, also removes related product plans and the associated product.

* **Documentation**
  * API docs updated to include the subscription deletion endpoint and authentication requirements.

* **Other**
  * Added a new success code for subscription deletion.

* **Chores**
  * Default active profile changed from dev to local.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->