### PR TITLE
멤버관련 프론트 요구사항 반영 및 오류 수정

### DIFF
--- a/src/main/java/com/dnd/sub/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/dnd/sub/domain/auth/repository/RefreshTokenRepository.java
@@ -9,7 +9,10 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     void deleteByRefreshToken(String refreshToken);
+
     void deleteByMember(Member member);
 
     Optional<RefreshToken> findByMember(Member member);
+
+    void deleteByMember_id(Long memberId);
 }

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.domain.member.controller;
 
+import com.dnd.sub.domain.member.dto.request.UpdateMemberNotificationRequest;
 import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
 import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
 import com.dnd.sub.domain.member.dto.response.MemberSuccessCode;
@@ -31,9 +32,8 @@ public class MemberController implements MemberControllerDocs {
     }
 
     @PatchMapping("/my/notification")
-    public ApiResponse<MemberInfoResponse> updateNotificationStatus(
-        @AuthenticationPrincipal Long memberId) {
-        MemberInfoResponse response = memberService.updateNotificationStatus(memberId);
+    public ApiResponse<MemberInfoResponse> updateNotificationStatus(@AuthenticationPrincipal Long memberId, @RequestBody UpdateMemberNotificationRequest request) {
+        MemberInfoResponse response = memberService.updateNotificationStatus(memberId, request);
         return ApiResponse.success(MemberSuccessCode.MEMBER_NOTI_UPDATE, response);
     }
 

--- a/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/dnd/sub/domain/member/controller/MemberControllerDocs.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.domain.member.controller;
 
+import com.dnd.sub.domain.member.dto.request.UpdateMemberNotificationRequest;
 import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
 import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
 import com.dnd.sub.domain.member.dto.response.MemberSuccessCode;
@@ -39,7 +40,7 @@ public interface MemberControllerDocs {
     )
     @PatchMapping("/my/notification")
     ApiResponse<MemberInfoResponse> updateNotificationStatus(
-        @AuthenticationPrincipal Long memberId);
+        @AuthenticationPrincipal Long memberId, @RequestBody UpdateMemberNotificationRequest request);
 
     @Operation(
         summary = "회원 탈퇴",

--- a/src/main/java/com/dnd/sub/domain/member/dto/request/UpdateMemberNotificationRequest.java
+++ b/src/main/java/com/dnd/sub/domain/member/dto/request/UpdateMemberNotificationRequest.java
@@ -1,0 +1,6 @@
+package com.dnd.sub.domain.member.dto.request;
+
+public record UpdateMemberNotificationRequest(
+    Boolean isNotificationOn
+) {
+}

--- a/src/main/java/com/dnd/sub/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/sub/domain/member/entity/Member.java
@@ -34,8 +34,8 @@ public class Member extends BaseEntity {
     @Column(columnDefinition = "TINYINT(1)")
     private boolean isNotificationOn = true;
 
-    public void updateIsNotificationOn() {
-      this.isNotificationOn = !this.isNotificationOn;
+    public void updateIsNotificationOn(boolean notificationOn) {
+      this.isNotificationOn = notificationOn;
   }
 
     public void updateEmail(String email) {

--- a/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.dnd.sub.domain.member.service;
 
 import com.dnd.sub.domain.auth.repository.RefreshTokenRepository;
+import com.dnd.sub.domain.member.dto.request.UpdateMemberNotificationRequest;
 import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
 import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
 import com.dnd.sub.domain.member.entity.Member;
@@ -42,9 +43,9 @@ public class MemberService {
     }
 
     @Transactional
-    public MemberInfoResponse updateNotificationStatus(final Long memberId) {
+    public MemberInfoResponse updateNotificationStatus(final Long memberId, final UpdateMemberNotificationRequest request) {
         Member member = findById(memberId);
-        member.updateIsNotificationOn();
+        member.updateIsNotificationOn(request.isNotificationOn());
         return new MemberInfoResponse(member.getEmail(), member.getName(),
             member.isNotificationOn());
     }

--- a/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/sub/domain/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package com.dnd.sub.domain.member.service;
 
+import com.dnd.sub.domain.auth.repository.RefreshTokenRepository;
 import com.dnd.sub.domain.member.dto.request.UpdateMemberRequest;
 import com.dnd.sub.domain.member.dto.response.MemberInfoResponse;
 import com.dnd.sub.domain.member.entity.Member;
@@ -17,6 +18,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final SubscriptionService subscriptionService;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional(readOnly = true)
     public Member findById(final Long id) {
@@ -52,6 +54,7 @@ public class MemberService {
         Member member = findById(memberId);
 
         deleteAllMemberSubscriptions(memberId);
+        deleteRefreshToken(memberId);
         deleteMemberInfo(memberId);
     }
 
@@ -61,5 +64,9 @@ public class MemberService {
 
     private void deleteMemberInfo(final Long memberId) {
         memberRepository.deleteById(memberId);
+    }
+
+    private void deleteRefreshToken(final Long memberId) {
+        refreshTokenRepository.deleteByMember_id(memberId);
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #97

### 📝 작업 내용
- 회원탈퇴 오류 해결
- 알람 상태를 request response에도 사용

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now explicitly set your notification preference (on/off) via the notification settings endpoint instead of toggling.
  - When an account is deleted, all active login sessions are invalidated for improved security.

- Improvements
  - More predictable notification updates using a clear request payload.

- Documentation
  - API docs updated to reflect the new request body for updating notification settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->