### PR TITLE
stared_at 이 null일때 NPE해결

### DIFF
--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -266,7 +266,7 @@ public class SubscriptionService {
             product.getImageUrl(),
             subscription.getPayCycleUnit(),
             subscription.getStartedAt(),
-            (int) subscription.getPayCycleUnit().getChronoUnit().between(subscription.getStartedAt(), LocalDate.now()),
+            computeCycles(subscription),
             productPlan.getPrice(),
             productPlan.getName(),
             subscription.getPaymentMethod().getId(),
@@ -319,5 +319,12 @@ public class SubscriptionService {
     private ProductPlan getProductPlanBySubscription(final Subscription subscription) {
         return productPlanRepository.findById(subscription.getPlanId())
             .orElseThrow(() -> new ProductPlanException(ProductPlanErrorCode.PRODUCT_PLAN_NOT_FOUND));
+    }
+
+    private int computeCycles(Subscription subscription) {
+        if(subscription.getPayCycleUnit() == null || subscription.getStartedAt() == null){
+            return 0;
+        }
+        return (int) subscription.getPayCycleUnit().getChronoUnit().between(subscription.getStartedAt(), LocalDate.now());
     }
 }


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #103


### 📝 작업 내용
- 날짜가 null일때 NPE가 발생하는것을 해결하였습니다.

### 📢 참고 사항
(참고사항이 없다면 X를 남겨주세요)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when viewing subscription details if cycle unit or start date is missing; cycles now display as 0 in such cases.
* **Refactor**
  * Centralized subscription cycle calculation to a single helper for consistent behavior and easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->