### PR TITLE
planId대신 productId반환

### DIFF
--- a/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDetailInfoDto.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/GetMySubscriptionDetailInfoDto.java
@@ -15,7 +15,7 @@ public record GetMySubscriptionDetailInfoDto(
     int totalPaymentCount,
     int price,
     String planName,
-    Long planId,
+    Long productId,
     boolean isCustom,
     Long paymentMethodId,
     String memo,

--- a/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetMySubscriptionDetailInfoResponse.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/dto/response/GetMySubscriptionDetailInfoResponse.java
@@ -36,7 +36,7 @@ public record GetMySubscriptionDetailInfoResponse(
             dto.totalPaymentCount(),
             dto.price(),
             dto.planName(),
-            dto.planId(),
+            dto.productId(),
             dto.isCustom(),
             dto.paymentMethodId(),
             dto.memo(),

--- a/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/dnd/sub/domain/subscription/service/SubscriptionService.java
@@ -269,7 +269,7 @@ public class SubscriptionService {
             computeCycles(subscription),
             productPlan.getPrice(),
             productPlan.getName(),
-            subscription.getPlanId(),
+            product.getId(),
             !product.isAdminWritten(),
             subscription.getPaymentMethod().getId(),
             subscription.getMemo(),


### PR DESCRIPTION
### #️⃣연관된 이슈
Resolves #107

### 📝 작업 내용
- planId대신 productId를 반환합니다

### 📢 참고 사항
X

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the subscription detail field from planId to productId across responses, ensuring consistent terminology. The value remains the same type (Long), but the serialized field name has changed.
  - Clients consuming subscription detail endpoints must update integrations to read productId instead of planId.
  - Verify any UI labels, analytics, and downstream mappings that referenced planId to prevent breakages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->